### PR TITLE
Fix for Windows 8/8.1 and server 2012/R2

### DIFF
--- a/Contents/Libraries/Shared/execjs/__init__.py
+++ b/Contents/Libraries/Shared/execjs/__init__.py
@@ -489,8 +489,8 @@ _runtimes['SpiderMonkey'] = _runtimes['Spidermonkey'] = ExternalRuntime(
 
 _runtimes['JScript'] = ExternalRuntime(
     name        = "JScript",
-    command     = ["cscript", "//E:jscript", "//Nologo", "//U"],
-    encoding    = 'UTF-16LE', # CScript with //U returns UTF-16LE
+    command     = ["cscript", "//E:jscript", "//Nologo"],
+    encoding    = 'UTF-8',
     runner_source = r"""(function(program, execJS) { execJS(program) })(function() {
   return eval(#{encoded_source});
 }, function(program) {

--- a/Contents/Libraries/Shared/spotify_web/friendly.py
+++ b/Contents/Libraries/Shared/spotify_web/friendly.py
@@ -573,7 +573,8 @@ class Spotify():
         self.global_lock = Lock()
         self.api = SpotifyAPI(log_level=log_level)
         self.api.connect(username, password)
-        self.tunigo = Tunigo(region=self.api.country)
+        if self.api.is_logged_in:
+            self.tunigo = Tunigo(region=self.api.country)
 
     def logged_in(self):
         return self.api.is_logged_in and not self.api.disconnecting

--- a/Contents/Libraries/Shared/spotify_web/spotify.py
+++ b/Contents/Libraries/Shared/spotify_web/spotify.py
@@ -993,13 +993,15 @@ class SpotifyAPI():
 
     def work(self, payload):
         Logging.debug("Got do_work message, payload: " + payload)
+        try:
+            ctx = execjs.compile(WORK_RUNNER % payload)
+            result = ctx.eval('main.run.call(main)')
+            Logging.debug('Work result: %s' % result)
 
-        ctx = execjs.compile(WORK_RUNNER % payload)
-        result = ctx.eval('main.run.call(main)')
-
-        Logging.debug('Work result: %s' % result)
-
-        return self.send_command("sp/work_done", result, self.work_callback)
+            return self.send_command("sp/work_done", result, self.work_callback)
+        except Exception, e:
+            Logging.error("There was a problem while do_work. Message: " + str(e))
+            return False
 
     def work_callback(self, sp, resp):
         Logging.debug("Got ack for message reply")

--- a/Contents/Libraries/Shared/spotify_web/tunigoapi.py
+++ b/Contents/Libraries/Shared/spotify_web/tunigoapi.py
@@ -9,7 +9,7 @@ IMAGE_HOST = "d3rt1990lpmkn.cloudfront.net"
 class Tunigo():
 
     def __init__(self, region = "us"):
-        self.region   = region
+        self.region = "us" if region is None else region
         self.root_url = "https://api.tunigo.com/v3/space/"
         Logging.debug("Starting with Tunigo for region: "  + self.region)
 


### PR DESCRIPTION
execjs din't run correctly in new windows enviroments
